### PR TITLE
Add file open error-checking in registration

### DIFF
--- a/login.cpp
+++ b/login.cpp
@@ -62,7 +62,6 @@ void login::Registration()
         }
         f1 << regUser << ' ' << hashPassword << ' ' << securityHash << endl;
         system("clear");
-        #endif
         cout << "\n\t\t\t Registration successful!\n";
         return;
     }
@@ -159,9 +158,9 @@ void login::ForgotPassword()
 {
     #ifdef _WIN32
             system("cls");
-        #else
+    #else
             system("clear");
-        #endif
+    #endif
 /*     string forgotChoice, count, secondCount;
     
     cout << "\n\t\t\tPress 1 to enter USERNAME\n";

--- a/login.cpp
+++ b/login.cpp
@@ -56,6 +56,10 @@ void login::Registration()
     if (input.tellg() == 0)
     {
         ofstream f1("data.txt", ios::app);
+        if(!f1){
+            cerr<<"Error opening file for writing."<<endl;
+            return;
+        }
         f1 << regUser << ' ' << hashPassword << ' ' << securityHash << endl;
         system("clear");
         cout << "\n\t\t\t Registration successful!\n";

--- a/login.cpp
+++ b/login.cpp
@@ -62,12 +62,17 @@ void login::Registration()
         }
         f1 << regUser << ' ' << hashPassword << ' ' << securityHash << endl;
         system("clear");
+        #endif
         cout << "\n\t\t\t Registration successful!\n";
         return;
     }
     else
     {
         ifstream input("data.txt");
+        if(!input){
+            cerr<<"Error opening file to reading."<<endl;
+            return;
+        }
         while (input >> regId >> regPass >> regSecure)
         {
             if (regUser == regId)
@@ -152,8 +157,13 @@ void login::DrunkGame()
 
 void login::ForgotPassword()
 {
+    #ifdef _WIN32
+            system("cls");
+        #else
+            system("clear");
+        #endif
 /*     string forgotChoice, count, secondCount;
-    system("clear");
+    
     cout << "\n\t\t\tPress 1 to enter USERNAME\n";
     cout << "\t\t\tPress 2 to go back to MENU\n";
     cout << "\n\t\t\tEnter choice: ";


### PR DESCRIPTION
Change 1-This code adds error handling for file writing. It checks if the output file stream (`ofstream`) fails to open and, if so, logs an error message to `cerr` and exits the function gracefully. This prevents the program from proceeding with file operations if the file cannot be accessed, enhancing the program's robustness.

Change 2-This code checks if the file fails to open for reading. If the file cannot be opened (`!input`), it prints an error message and exits the function (`return`). This ensures the program handles file access errors gracefully.

Change 3-This code clears the console screen in a platform-independent way. It checks the operating system at compile-time: `system("cls")` is used for Windows (`_WIN32`), and `system("clear")` for Unix/Linux. The `#endif marks the end of this conditional directive.